### PR TITLE
no more Dataset; now every Data has its origin at the start of its hi…

### DIFF
--- a/pjml/tool/collection/expand/expand.py
+++ b/pjml/tool/collection/expand/expand.py
@@ -11,6 +11,4 @@ class Expand(LightConfigLess, Invisible):
         return Model(self, data, applied)
 
     def _use_impl(self, data, *args):
-        return InfiniteCollection(
-            data, data.history, data.failure, data.dataset
-        )
+        return InfiniteCollection(data, data.history, data.failure)

--- a/pjml/tool/collection/reduce/summ.py
+++ b/pjml/tool/collection/reduce/summ.py
@@ -2,6 +2,7 @@ import numpy
 from numpy import mean
 from numpy import std
 from pjdata.data import Data
+from pjdata.history import History
 
 from pjml.config.description.cs.transformercs import TransformerCS
 from pjml.config.description.distributions import choice
@@ -31,13 +32,12 @@ class Summ(Reduce):
         if collection.has_nones:
             # collection = Shrink().apply(collection)
             raise Exception(
-                "Warning: You shuld use 'Shirink()' to handling collections with None. ")
+                "Warning: You shuld use 'Shirink()' to handling collections "
+                "with None. ")
 
         data = Data(
-            dataset=collection.dataset,
-            failure=collection.failure
-        ).updated(
-            collection.history.transformations,
+            History(collection.history.transformations),
+            failure=collection.failure,
             **collection.original_data.matrices
         )
 

--- a/pjml/tool/data/flow/file.py
+++ b/pjml/tool/data/flow/file.py
@@ -1,8 +1,11 @@
+from functools import lru_cache
+
 from pjdata.data_creation import read_arff
+from pjdata.step.transformation import Transformation
 from pjml.config.description.cs.transformercs import TransformerCS
 from pjml.config.description.node import Node
 from pjml.config.description.parameter import FixedP
-from pjml.tool.abc.invisible import Invisible
+from pjml.tool.abc.lighttransformer import LightTransformer
 from pjml.tool.abc.mixin.nodatahandler import NoDataHandler
 
 # Precisa herdar de Invisible, pois o mesmo Data pode vir de diferentes
@@ -11,11 +14,11 @@ from pjml.tool.abc.mixin.nodatahandler import NoDataHandler
 from pjml.tool.model import Model
 
 
-class File(Invisible, NoDataHandler):
+class File(LightTransformer, NoDataHandler):
     """Source of Data object from CSV, ARFF, file.
 
     TODO: always classification task?
-    There will be no transformations (history) on the generated Data.
+    There will be a single transformation (history) on the generated Data.
 
     A short hash will be added to the name, to ensure unique names.
     Actually, the first collision is expected after 12M different datasets
@@ -26,14 +29,35 @@ class File(Invisible, NoDataHandler):
     In practice, no more than a dozen are expected.
     """
 
-    def __init__(self, name, path='./', description='No description.'):
-        config = self._to_config(locals())
+    def __init__(self,
+                 name, path='./',
+                 description='No description.',
+                 matrices_hash=None):
+
+        # Some checking.
         if not path.endswith('/'):
             raise Exception('Path should end with /', path)
         if name.endswith('arff'):
             data = read_arff(path + name, description)
         else:
             raise Exception('Unrecognized file extension:', name)
+        if matrices_hash:
+            if 'f' + matrices_hash != data.history[0].transformer_uuid:
+                raise Exception(
+                    f'Provided hash f{matrices_hash} differs from actual hash '
+                    f'{data.history[0].transformer_uuid}!')
+        else:
+            matrices_hash = data.history[0].transformer_uuid[1:]
+
+        # Unique config for this file.
+        config = {
+            'name': name,
+            'path': path,
+            'description': description,
+            'matrices_hash': matrices_hash
+        }
+        self.matrices_hash = matrices_hash
+
         super().__init__(config, deterministic=True)
         self.data = data
 
@@ -47,9 +71,17 @@ class File(Invisible, NoDataHandler):
 
     @classmethod
     def _cs_impl(cls):
+        from pjdata.mixin.identifyable import Identifyable
         params = {
             'path': FixedP('./'),
             'name': FixedP('iris.arff'),
-            'description': FixedP('No description.')
+            'description': FixedP('No description.'),
+            'matrices_hash': Identifyable.nothing
         }
         return TransformerCS(Node(params=params))
+
+    def transformations(self, step, clean=True):
+        return [Transformation(self, 'u')]
+
+    def _uuid_impl(self):
+        return 'uuid', 'f' + self.matrices_hash


### PR DESCRIPTION
With this spectacular change, every Data object will be completely identifyable, no matter what happens in its troubled life.
Only File is a reliable source for now.
Except for the prefix, File uuid is exactly the same as the matrices hash.
Fields ('matrices')  'D' and 'N' can provide the description and name of original dataset.